### PR TITLE
yaml-validator: Extend glob to include `yaml` files

### DIFF
--- a/src/yaml-validator.ts
+++ b/src/yaml-validator.ts
@@ -25,7 +25,7 @@ export const validateYaml = async ( workspaceRoot: string): Promise<ValidationRe
         //TODO: improve this implementation - e.g. use the glob patterns from the yaml.schemas settings        
         const filePaths = await new Promise<string[]>((c,e) => {
             glob(
-                '**/*.yml', 
+                '**/*.{yml,yaml}', 
                 {
                     cwd : workspaceRoot,
                     silent : true,


### PR DESCRIPTION
As the title suggests this PR does a simple change to `yaml-validator` to also include `yaml` files in the glob.

I would love to also update the `lib/index.js` but my experience with TypeScript is non-existent. As such I'm helpful for any pointers.