### PR TITLE
yaml-validator: Use the glob patterns from the yaml.schemas settings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+on: [push]
+jobs:
+  Use-Action:
+    name: Use Action
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - id: validate-yaml-schema
+        uses: ./
+        with:
+          yamlSchemasJson: |
+            {
+              "https://json.schemastore.org/github-action.json": ["action.yml", "action.yaml"],
+              "https://json.schemastore.org/github-workflow.json": [".github/workflows/*.yml", ".github/workflows/*.yaml"]
+            }
+      - run: |
+          for f in action.yml .github/workflows/test.yml; do
+            if $(jq "split(\",\") | all(. != \"$f\")" <<< '"${{ steps.validate-yaml-schema.outputs.validFiles }}"'); then
+              echo "$f was not validated"
+              exit 1
+            fi
+          done
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All you need is a **.vscode/settings.json** document at the root of the reposito
 
 ### `settingsFile` (optional)
 
-Location of the schema configuration file.  
+Location of the schema configuration file.
 
 The default location is **.vscode/settings.json**, you can change it do a different location but it but still be a json document containing the `yaml.schemas` config.
 See the [VS Code YAML Extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) for how to structure the config.
@@ -35,9 +35,13 @@ Instead of adding the `yaml.schemas` config to a file, you can instead supply it
 
 ## Outputs
 
+### `validFiles`
+
+A comma separated list of files that passed the schema validation.
+
 ### `invalidFiles`
 
-A comma separated list of files that failed the schema validation.  
+A comma separated list of files that failed the schema validation.
 
  > Schema validation fails if any results are returned from the YAML Language Server
 
@@ -49,6 +53,6 @@ A comma separated list of files that failed the schema validation.
       - uses: nwisbeta/validate-yaml-schema@v1.0.3
 
 ## Thanks
-This action has been made by 're-mixing' logic from these repos: 
- - https://github.com/OrRosenblatt/validate-json-action 
+This action has been made by 're-mixing' logic from these repos:
+ - https://github.com/OrRosenblatt/validate-json-action
  - https://github.com/redhat-developer/yaml-language-server

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'YAML Schema Validator'
 description: 'Validate YAML files in a repo according to settings'
 inputs:
-  settingsFile: 
+  settingsFile:
     description: 'Location of schema configuration file'
     required: false
     default: '.vscode/settings.json'
@@ -9,11 +9,13 @@ inputs:
     description: 'The yaml.schemas config as inline JSON'
     required: false
 outputs:
-  invalidFiles: 
+  validFiles:
+    description: 'Comma separated list of files that passed the schema validation'
+  invalidFiles:
     description: 'Comma separated list of files that failed the schema validation'
 runs:
   using: 'node12'
   main: 'lib/index.js'
-branding: 
+branding:
   icon: 'check'
   color: orange

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Validate a YAML file against a JSON Schema",
   "main": "lib/index.js",
   "scripts": {
-    "start": "webpack --config webpack.config.js && node lib/index.js",
+    "build": "webpack --config webpack.config.js",
+    "start": "npm run build && node lib/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "tsc": "tsc"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,13 +27,16 @@ async function run() {
     }
     const schemas = {...settingsYamlSchemas, ...inlineYamlSchemas };
 
-   
+
     const validationResults = await validateYaml(workspaceRoot, schemas);
 
+    const validResults = validationResults.filter(res => res.valid).map(res => res.filePath);
     const invalidResults = validationResults.filter(res => !res.valid).map(res => res.filePath);
 
+    const validFiles = validResults.length > 0 ? validResults.join(',') : '';
     const invalidFiles = invalidResults.length > 0 ? invalidResults.join(',') : '';
 
+    core.setOutput('validFiles', validFiles);
     core.setOutput('invalidFiles', invalidFiles);
 
     if (invalidResults.length > 0) {

--- a/src/yaml-validator.ts
+++ b/src/yaml-validator.ts
@@ -28,6 +28,7 @@ export const validateYaml = async ( workspaceRoot: string, schemas: any): Promis
                         cwd : workspaceRoot,
                         silent : true,
                         nodir : true,
+                        matchBase : true
                     },
                     (err, files) => {
                         if (err) {

--- a/src/yaml-validator.ts
+++ b/src/yaml-validator.ts
@@ -18,9 +18,7 @@ export const validateYaml = async ( workspaceRoot: string, schemas: any): Promis
 
         const schemaValidator = new SchemaValidator(schemas, workspaceRoot);
 
-        const filePathPatternsBySchema: any = Object.values(schemas)
-        const filePathPatterns = ['**/*.{yml,yaml}'].concat(...filePathPatternsBySchema);
-
+        const filePathPatterns = [].concat(...Object.values(schemas));
 
         const filePathsByPattern = await Promise.all(filePathPatterns.map(async filePathPattern => {
             return await new Promise<string[]>((c,e) => {


### PR DESCRIPTION
Also resolves https://github.com/nwisbeta/validate-yaml-schema/issues/11

### Description

I've discovered that the action does not work if the YAMLs are more than 1 directory away from the workspace root:
- ✅ `action.yml`
- ✅ `dir1/action.yml`
- ❗ `dir2/dir1/action.yml`

I believe this happens because GitHub actions environment does not have `shopt -s globstar` enabled. 

###### Glob Patterns

I changed the glob pattern that is used to find YAMLs from `**/*.{yml,yaml}` to all the values from `schemas`. This enables users to explicitly define which files should be validated.

###### Outputs

I added `validFiles` to the outputs. That way it is possible to verify if all the expected files were validated.

###### Tests

I added a test that performs the validation of the `action.yml` and `test.yml` from this repository.

### Testing

- [x] Ran the test on `ubuntu-latest`, `macos-latest` and `windows-latest` https://github.com/galargh/validate-yaml-schema/actions/runs/1678592479
