### PR TITLE
allow searching dot directories by default

### DIFF
--- a/src/yaml-validator.ts
+++ b/src/yaml-validator.ts
@@ -28,7 +28,8 @@ export const validateYaml = async ( workspaceRoot: string, schemas: any): Promis
                         cwd : workspaceRoot,
                         silent : true,
                         nodir : true,
-                        matchBase : true
+                        matchBase : true,
+                        dot: true
                     },
                     (err, files) => {
                         if (err) {


### PR DESCRIPTION
###### Description

I've just discovered that a problem that I've noticed in https://github.com/nwisbeta/validate-yaml-schema/pull/20 was not correctly diagnosed.

*I believe this happens because GitHub actions environment does not have shopt -s globstar enabled.* - this is not true.

I examined https://github.com/isaacs/node-glob package more closely and found out that for `**/*.yml` pattern to find `.github/workflows/test.yml`, for example, a `dot` option (which allows searching dot directories) has to be enabled (it is disabled by default).

I still believe the changes introduced in https://github.com/nwisbeta/validate-yaml-schema/pull/20 are enhancements to the action so thank you for merging them 🙇 I wanted to let you know about this new development anyway.

In this PR, I propose to add the `dot: true` setting to `glob` call for completeness. 

###### Testing

I tested it here: https://github.com/galargh/validate-yaml-schema/actions/runs/1678650750 (it uses `test.yml` as a pattern instead of `.github/workflows/*.yml` in the test workflow).
