### PR TITLE
fix: read yaml version from input and config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ The default location is **.vscode/settings.json**, you can change it do a differ
 See the [VS Code YAML Extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) for how to structure the config.
 
 
+### `yamlVersion` (optional)
+
+Yaml version used for validation, default is `1.2` or the value read from `yaml.yamlVersion` key in **.vscode/settings.json**
+
+
 ### `yamlSchemasJson` (optional)
 
 The yaml.schemas config as inline JSON
@@ -21,7 +26,7 @@ The yaml.schemas config as inline JSON
 Instead of adding the `yaml.schemas` config to a file, you can instead supply it as inline JSON, e.g.:
 
 ```yaml
-      - uses: nwisbeta/validate-yaml-schema@v1.0.3
+      - uses: nwisbeta/validate-yaml-schema@v2.0.0
         with:
           yamlSchemasJson: |
             {

--- a/src/file-reader.ts
+++ b/src/file-reader.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { TextDocument } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { InvalidFileError } from './errors';
 
 export const getYaml = async (filePath: string): Promise<TextDocument> => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ async function run() {
 
     const settingsFile = core.getInput('settingsfile');
     const yamlSchemasJson = core.getInput('yamlSchemasJson');
+    const yamlVersionInput = core.getInput('yamlVersion');
 
     // Settings checking
 
@@ -21,14 +22,17 @@ async function run() {
     }
 
     let settingsYamlSchemas;
-    if (fs.existsSync(settingsFile)){
+    let settingsYamlVersion;
+    if (fs.existsSync(path.join(workspaceRoot, settingsFile))){
       const settings  = await getJson(path.join(workspaceRoot, settingsFile));
       settingsYamlSchemas = settings ? settings['yaml.schemas'] : null;
+      settingsYamlVersion = settings ? settings['yaml.yamlVersion']: null;
     }
     const schemas = {...settingsYamlSchemas, ...inlineYamlSchemas };
 
+    const yamlVersion = yamlVersionInput ? yamlVersionInput : settingsYamlVersion;
 
-    const validationResults = await validateYaml(workspaceRoot, schemas);
+    const validationResults = await validateYaml(workspaceRoot, schemas, yamlVersion);
 
     const validResults = validationResults.filter(res => res.valid).map(res => res.filePath);
     const invalidResults = validationResults.filter(res => !res.valid).map(res => res.filePath);

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -2,13 +2,15 @@ import * as URL from 'url';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { LanguageSettings } from 'yaml-language-server'
 import { YAMLValidation } from 'yaml-language-server/lib/umd/languageservice/services/yamlValidation'
+import { YamlVersion } from 'yaml-language-server/lib/umd/languageservice/parser/yamlParser07'
 import { YAMLSchemaService } from 'yaml-language-server/lib/umd/languageservice/services/yamlSchemaService'
 import { schemaRequestHandler } from './services/schemaRequestHandler'
 
 export class SchemaValidator { 
 
-  constructor(schemaSettings : any, workspaceRoot : string) {
+  constructor(schemaSettings : any, workspaceRoot : string, yamlVersion: string) {
     this.addSchemaSettings(schemaSettings);     
+    this.setYamlVersion(yamlVersion)
     this.buildValidator(workspaceRoot);
   }
 
@@ -23,6 +25,11 @@ export class SchemaValidator {
     schemas: [],
     customTags: []
   };
+
+  private setYamlVersion(version: string) {
+    const yamlVersion = version? <YamlVersion>(version) : <YamlVersion>"1.2";
+    this.languageSettings.yamlVersion = yamlVersion;
+  }
 
   private addSchemaSettings(schemaSettings) {
   

--- a/src/yaml-validator.ts
+++ b/src/yaml-validator.ts
@@ -9,14 +9,14 @@ export interface ValidationResult {
     valid: boolean;
 }
 
-export const validateYaml = async ( workspaceRoot: string, schemas: any): Promise<ValidationResult[]> => {
+export const validateYaml = async ( workspaceRoot: string, schemas: any, yamlVersion: string): Promise<ValidationResult[]> => {
 
     try {
 
         if(!schemas || Object.keys(schemas).length === 0)
             throw 'no schema settings found';
 
-        const schemaValidator = new SchemaValidator(schemas, workspaceRoot);
+        const schemaValidator = new SchemaValidator(schemas, workspaceRoot, yamlVersion);
 
         const filePathPatterns = [].concat(...Object.values(schemas));
 


### PR DESCRIPTION
## Overview

Yaml validator returns true and logs error if yaml version is not passed

- [x] read yaml version from input
- [x] read yaml version from config file
- [x] set default yaml version if missing (default `1.2`)  

Fixes #24 